### PR TITLE
Synchronization of the turorial notebooks folder through a temporary folder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ Changes:
 
 Fixes:
 ------
-- The deploy_data_specifi_image script now mirrors the git repository. 
+- The deploy_data_specific_image script now mirrors the git repository. Fixes problem with renamed or deleted files not being updated.
   
 
 0.2.1 (2021-06-01)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,17 @@ Changes:
 Fixes:
 ------
 - ...
+0.2.2 (2021-09-10)
+===================
+
+Changes:
+--------
+- Add rsync installation, used for the deployement of notebooks in jupyterhub.
+
+Fixes:
+------
+- The deploy_data_specifi_image script now mirrors the git repository. 
+  
 
 0.2.1 (2021-06-01)
 ===================

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,11 +16,11 @@ Fixes:
 
 Changes:
 --------
-- Add rsync installation, used for the deployement of notebooks in jupyterhub.
+- Add rsync installation, used for the deployment of notebooks in jupyterhub.
 
 Fixes:
 ------
-- The deploy_data_specific_image script now mirrors the git repository. Fixes problem with renamed or deleted files not being updated.
+- The `deploy_data_specific_image` script now mirrors the git repository. Fixes problem with renamed or deleted files not being updated.
   
 
 0.2.1 (2021-06-01)

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,12 +4,9 @@ RUN conda update conda
 
 # to checkout other notebooks and to run pip install
 RUN apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y git mercurial gcc jq && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y git mercurial gcc jq rsync && \
     apt-get clean
-
-# Installation of rsync used for the notebooks deployement
-RUN apt-get -y install rsync
-
+    
 COPY environment /environment
 
 # needed for our specific jenkins

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,9 @@ RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y git mercurial gcc jq && \
     apt-get clean
 
+# Installation of rsync used for the notebooks deployement
+RUN apt-get -y install rsync
+
 COPY environment /environment
 
 # needed for our specific jenkins

--- a/scheduler-jobs/deploy_data_specific_image
+++ b/scheduler-jobs/deploy_data_specific_image
@@ -82,10 +82,14 @@ for ((i=0;i<$CONFIG_LIST_LENGTH;i++)); do
 
     echo "Extracting ${FULL_URL} to ${FULL_DEST_DIR}"
 
-    # Download the data from github and copy it to the destination directory
-    # TODO: Handle renamed or deleted notebooks, since this command only copies the content of the source_dir in the dest_dir
-    # For now, any other file found in the dest_dir are not handled and remain in its location.
-    svn export --force $FULL_URL $FULL_DEST_DIR
+    # Download the data from github into tmp directory
+    svn export --force $FULL_URL tmp
+
+    # Synchronize source_dir with dest_dir
+    # --delete : delete extraneous files from destination dirs
+    rsync -rtovcs --delete tmp/ $FULL_DEST_DIR/
+    # Remove tmp directory
+    rm -r tmp
 done
 
 echo "notebookdeploy finished   END_TIME=`date -Isecond`"

--- a/scheduler-jobs/deploy_data_specific_image
+++ b/scheduler-jobs/deploy_data_specific_image
@@ -86,7 +86,7 @@ for ((i=0;i<$CONFIG_LIST_LENGTH;i++)); do
     # Download the data from github into tmp directory
     svn export --force $FULL_URL $FULL_TMP_DIR
 
-    # Synchronize source_dir with dest_dir
+    # Synchronize FULL_TMP_DIR with FULL_DEST_DIR
     # --delete : delete extraneous files from destination dirs
     rsync --recursive --delete --times --checksum --protect-args $FULL_TMP_DIR/ $FULL_DEST_DIR/
 done

--- a/scheduler-jobs/deploy_data_specific_image
+++ b/scheduler-jobs/deploy_data_specific_image
@@ -88,7 +88,7 @@ for ((i=0;i<$CONFIG_LIST_LENGTH;i++)); do
 
     # Synchronize FULL_TMP_DIR with FULL_DEST_DIR
     # --delete : delete extraneous files from destination dirs
-    rsync --recursive --delete --times --checksum --protect-args $FULL_TMP_DIR/ $FULL_DEST_DIR/
+    rsync --recursive --delete --times --checksum --protect-args --verbose $FULL_TMP_DIR/ $FULL_DEST_DIR/
 done
 
 # Remove /tmp/notebooks directory

--- a/scheduler-jobs/deploy_data_specific_image
+++ b/scheduler-jobs/deploy_data_specific_image
@@ -80,17 +80,19 @@ for ((i=0;i<$CONFIG_LIST_LENGTH;i++)); do
     FULL_URL=$GIT_REPO/branches/$BRANCH/$SOURCE_DIR
     FULL_DEST_DIR=$DEPLOY_DATA_JOB_NOTEBOOK_DEST_DIR/$DEST_SUB_DIR
 
+    FULL_TMP_DIR="/tmp/notebooks/$(basename $(dirname $FULL_DEST_DIR))_$(basename $FULL_DEST_DIR)"
+
     echo "Extracting ${FULL_URL} to ${FULL_DEST_DIR}"
 
     # Download the data from github into tmp directory
-    svn export --force $FULL_URL tmp
+    svn export --force $FULL_URL $FULL_TMP_DIR
 
     # Synchronize source_dir with dest_dir
     # --delete : delete extraneous files from destination dirs
-    rsync -rtovcs --delete tmp/ $FULL_DEST_DIR/
-    # Remove tmp directory
-    rm -r tmp
+    rsync -rtovcs --delete $FULL_TMP_DIR $FULL_DEST_DIR/
 done
+# Remove tmp directory
+rm -r tmp
 
 echo "notebookdeploy finished   END_TIME=`date -Isecond`"
 

--- a/scheduler-jobs/deploy_data_specific_image
+++ b/scheduler-jobs/deploy_data_specific_image
@@ -88,10 +88,11 @@ for ((i=0;i<$CONFIG_LIST_LENGTH;i++)); do
 
     # Synchronize source_dir with dest_dir
     # --delete : delete extraneous files from destination dirs
-    rsync -rtovcs --delete $FULL_TMP_DIR $FULL_DEST_DIR/
+    rsync --recursive --delete --times --checksum --protect-args $FULL_TMP_DIR/ $FULL_DEST_DIR/
 done
-# Remove tmp directory
-rm -r $FULL_TMP_DIR
+
+# Remove /tmp/notebooks directory
+rm --recursive --force $(dirname $FULL_TMP_DIR)
 
 echo "notebookdeploy finished   END_TIME=`date -Isecond`"
 

--- a/scheduler-jobs/deploy_data_specific_image
+++ b/scheduler-jobs/deploy_data_specific_image
@@ -79,8 +79,7 @@ for ((i=0;i<$CONFIG_LIST_LENGTH;i++)); do
 
     FULL_URL=$GIT_REPO/branches/$BRANCH/$SOURCE_DIR
     FULL_DEST_DIR=$DEPLOY_DATA_JOB_NOTEBOOK_DEST_DIR/$DEST_SUB_DIR
-
-    FULL_TMP_DIR="/tmp/notebooks/$(basename $(dirname $FULL_DEST_DIR))_$(basename $FULL_DEST_DIR)"
+    FULL_TMP_DIR="/tmp/notebooks/item_$i"
 
     echo "Extracting ${FULL_URL} to ${FULL_DEST_DIR}"
 
@@ -92,7 +91,7 @@ for ((i=0;i<$CONFIG_LIST_LENGTH;i++)); do
     rsync -rtovcs --delete $FULL_TMP_DIR $FULL_DEST_DIR/
 done
 # Remove tmp directory
-rm -r tmp
+rm -r $FULL_TMP_DIR
 
 echo "notebookdeploy finished   END_TIME=`date -Isecond`"
 


### PR DESCRIPTION
Simple quick fix for the missing handling of removing files from the already deployed files into notebooks directory.

Problem :
The actual schronization does not verify if there are files already in the directory, it simply copy content from the git repo into the directory. So the repo and the notebooks directory on the server are not mirrored.

Example: 
If  X file is pushed to master, then the repo structure is modified --> move X file into Y folder. 
It will copy Y folder containing X,  beside the old X file. 

FIXE: 
1. Copy the git/notebooks content into a tmp directory
2. Synchronize the Destination_Dir with tmp, 
        2.1. while deleting extraneous files from destination directory
3. Remove the tmp directory.

RSYNC
- First sync:  if detination directory does not exist, it will create it
- Already existing destination directory : It will mirror the source(tmp) and destination directory, while deleting extranous files from destination and without overwriting files that are identical.



