### PR TITLE
Fix conda install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,18 +12,23 @@ Fixes:
 ------
 - ...
 
-0.3.0 (2022-12-13)
+0.3.0 (2022-12-20)
 ===================
 
 Changes:
 --------
 - Add a JupyterLab extension to display a message on the top bar, along with the file `plugin.json` to customize the 
   extension display.
+- Install requirements with `mamba` instead of `conda`, which greatly speeds up the installation steps and which avoids
+  lots of resolution conflicts.
 
 Fixes:
 ------
 - Fix bug while building JupyterLab (see [issue](https://github.com/jupyterlab/jupyterlab/issues/11248)).
 - Fix notebook scripts to use a specific commit id.
+- Pin `packaging` version to avoid a package installation error when using the `jupyterlab_conda` extension to install
+  packages from JupyterLab.
+- Pin some other requirements to avoid errors while installing environment during image build.
 
 0.2.2 (2021-09-10)
 ===================

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,24 +12,33 @@ Fixes:
 ------
 - ...
 
-0.3.0 (2022-12-20)
+0.4.0 (2022-12-23)
+===================
+
+Changes:
+--------
+- Install requirements with `mamba` instead of `conda`, which greatly speeds up the installation steps and which avoids
+  lots of resolution conflicts.
+
+Fixes:
+------
+- Pin `packaging` version to avoid a package installation error when using the `jupyterlab_conda` extension to install
+  packages from JupyterLab.
+- Pin `jupyterlab-git` version to avoid newer versions which are only compatible with JupyterLab v3.
+- Pin some other requirements to avoid errors while installing environment during image build.
+
+0.3.0 (2022-12-13)
 ===================
 
 Changes:
 --------
 - Add a JupyterLab extension to display a message on the top bar, along with the file `plugin.json` to customize the 
   extension display.
-- Install requirements with `mamba` instead of `conda`, which greatly speeds up the installation steps and which avoids
-  lots of resolution conflicts.
 
 Fixes:
 ------
 - Fix bug while building JupyterLab (see [issue](https://github.com/jupyterlab/jupyterlab/issues/11248)).
 - Fix notebook scripts to use a specific commit id.
-- Pin `packaging` version to avoid a package installation error when using the `jupyterlab_conda` extension to install
-  packages from JupyterLab.
-- Pin `jupyterlab-git` version to avoid newer versions which are only compatible with JupyterLab v3.
-- Pin some other requirements to avoid errors while installing environment during image build.
 
 0.2.2 (2021-09-10)
 ===================

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Fixes:
 - Fix notebook scripts to use a specific commit id.
 - Pin `packaging` version to avoid a package installation error when using the `jupyterlab_conda` extension to install
   packages from JupyterLab.
+- Pin `jupyterlab-git` version to avoid newer versions which are only compatible with JupyterLab v3.
 - Pin some other requirements to avoid errors while installing environment during image build.
 
 0.2.2 (2021-09-10)

--- a/environment/environment_jupyter_plugins.yml
+++ b/environment/environment_jupyter_plugins.yml
@@ -9,8 +9,8 @@ dependencies:
   # extension to produce .py files from notebook .ipynb files
   # fix to 1.8.2 since latest version is only compatible with jupyterlab 3.0
   - jupytext==1.8.2
-  # jupyterlab extension for git
-  - jupyterlab-git
+  # jupyterlab extension for git, pinned since 0.40.0 and after are only compatible with jupyterlab 3.0
+  - jupyterlab-git==0.24.0
   # jupyterlab extension for conda, fix to 4.1.0 since latest version is only compatible with jupyterlab 3.0
   - jupyter_conda==4.1.0
   # dependency of jupyter_conda, pinned to 21.0 to avoid "Invalid version: 'custom'" error with version 22.0, appearing

--- a/environment/environment_jupyter_plugins.yml
+++ b/environment/environment_jupyter_plugins.yml
@@ -13,4 +13,7 @@ dependencies:
   - jupyterlab-git
   # jupyterlab extension for conda, fix to 4.1.0 since latest version is only compatible with jupyterlab 3.0
   - jupyter_conda==4.1.0
+  # dependency of jupyter_conda, pinned to 21.0 to avoid "Invalid version: 'custom'" error with version 22.0, appearing
+  # when loading the list of available packages, which prevents the list from being loaded and displayed
+  - packaging==21.0
   - jupyter-archive

--- a/environment/environment_main.yml
+++ b/environment/environment_main.yml
@@ -4,6 +4,7 @@ channels:
   - conda-forge
   - defaults
 dependencies:
+  - python==3.9.7
   # to edit .ipynb
   - jupyter
   # to be launched by image jupyterhub/jupyterhub

--- a/environment/environment_visualization.yml
+++ b/environment/environment_visualization.yml
@@ -7,7 +7,8 @@ channels:
 dependencies:
   - matplotlib
   - bokeh
-  - jupyter_bokeh
+  # pin version to avoid newer versions which use jupyterlab 3
+  - jupyter_bokeh==2.0.4
   - panel
   - holoviews
   - geoviews


### PR DESCRIPTION
This PR fixes the last attempted build of the images.

Changes :
- Install requirements with `mamba` instead of `conda`, which greatly speeds up the installation steps and which avoids
  lots of resolution conflicts.

Fixes :
- Pin `packaging` version to avoid a package installation error when using the `jupyterlab_conda` extension to install
  packages from JupyterLab.
- Pin `jupyterlab-git` version to avoid newer versions which are only compatible with JupyterLab v3.
- Pin some other requirements to avoid errors while installing environment during image build.