### PR TITLE
Fix image name with versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,17 @@ Fixes:
 ------
 - ...
 
+0.4.1 (2023-01-11)
+===================
+
+Changes:
+--------
+- ...
+
+Fixes:
+------
+- Fix scheduler job to support displayed JupyterHub image names with versions.
+
 0.4.0 (2022-12-23)
 ===================
 

--- a/scheduler-jobs/deploy_data_pavics_jupyter.env
+++ b/scheduler-jobs/deploy_data_pavics_jupyter.env
@@ -24,7 +24,9 @@ fi
 
 for i in $( seq 1 $(echo $DOCKER_NOTEBOOK_IMAGES | wc -w)) ; do
     DEPLOY_DATA_JOB_DOCKER_IMAGE=`echo $DOCKER_NOTEBOOK_IMAGES | cut -d " " -f $i`
-    DEPLOY_DATA_JOB_JUPYTERHUB_IMAGE_NAME=`echo $JUPYTERHUB_IMAGE_SELECTION_NAMES | cut -d " " -f $i`
+
+    # Select image name i, and remove any text found after a ':' (used for versions)
+    DEPLOY_DATA_JOB_JUPYTERHUB_IMAGE_NAME=`echo $JUPYTERHUB_IMAGE_SELECTION_NAMES | cut -d " " -f $i | cut -d ":" -f 1`
 
     DEPLOY_DATA_JOB_JOB_NAME="notebookdeploy-${DEPLOY_DATA_JOB_JUPYTERHUB_IMAGE_NAME}"
     DEPLOY_DATA_JOB_JOB_DESCRIPTION="Auto-deploy tutorial notebooks for the image ${DEPLOY_DATA_JOB_DOCKER_IMAGE}"

--- a/scheduler-jobs/deploy_data_pavics_jupyter.env
+++ b/scheduler-jobs/deploy_data_pavics_jupyter.env
@@ -25,7 +25,7 @@ fi
 for i in $( seq 1 $(echo $DOCKER_NOTEBOOK_IMAGES | wc -w)) ; do
     DEPLOY_DATA_JOB_DOCKER_IMAGE=`echo $DOCKER_NOTEBOOK_IMAGES | cut -d " " -f $i`
 
-    # Select image name i, and remove any text found after a ':' (used for versions)
+    # Select image name i, and keep only the name if using the '<name>:<version>' format
     DEPLOY_DATA_JOB_JUPYTERHUB_IMAGE_NAME=`echo $JUPYTERHUB_IMAGE_SELECTION_NAMES | cut -d " " -f $i | cut -d ":" -f 1`
 
     DEPLOY_DATA_JOB_JOB_NAME="notebookdeploy-${DEPLOY_DATA_JOB_JUPYTERHUB_IMAGE_NAME}"


### PR DESCRIPTION
Fix scheduler job to support displayed JupyterHub image names with versions.

Related to [birdhouse-deploy PR](https://github.com/bird-house/birdhouse-deploy/pull/275).