### PR TITLE
avoid parsing error of `DOCKER_NOTEBOOK_IMAGES` and `JUPYTERHUB_IMAGE_SELECTION_NAMES` using newlines

### DIFF
--- a/scheduler-jobs/deploy_data_pavics_jupyter.env
+++ b/scheduler-jobs/deploy_data_pavics_jupyter.env
@@ -18,29 +18,34 @@ DEPLOY_DATA_JOB_CONFIG="/notebook_config.yml"
 # Cronjob schedule.
 if [ -z "$DEPLOY_DATA_JOB_SCHEDULE" ]; then
     echo "Error: DEPLOY_DATA_JOB_SCHEDULE not set" 1>&2
-    exit 1
+    return 1
     #DEPLOY_DATA_JOB_SCHEDULE="3 1,4,7,10,13,16,19,22 * * *"  # UTC
 fi
 
-for i in $( seq 1 $(echo $DOCKER_NOTEBOOK_IMAGES | wc -w)) ; do
-    DEPLOY_DATA_JOB_DOCKER_IMAGE=`echo $DOCKER_NOTEBOOK_IMAGES | cut -d " " -f $i`
+# Normalize the variable format in case it contains additional spaces or employs newlines.
+DOCKER_NOTEBOOK_IMAGES=$(echo "${DOCKER_NOTEBOOK_IMAGES}" | grep -oP '\S+' | tr '[:space:]' ' ')
+echo "DOCKER_NOTEBOOK_IMAGES: [${DOCKER_NOTEBOOK_IMAGES}]"
+
+for i in $( seq 1 "$(echo "${DOCKER_NOTEBOOK_IMAGES}" | wc -w)" ) ; do
+    DEPLOY_DATA_JOB_DOCKER_IMAGE=$(echo "${DOCKER_NOTEBOOK_IMAGES}" | cut -d " " -f $i)
 
     # Select image name i, and keep only the name if using the '<name>:<version>' format
-    DEPLOY_DATA_JOB_JUPYTERHUB_IMAGE_NAME=`echo $JUPYTERHUB_IMAGE_SELECTION_NAMES | cut -d " " -f $i | cut -d ":" -f 1`
+    DEPLOY_DATA_JOB_JUPYTERHUB_IMAGE_NAME=$(echo "${JUPYTERHUB_IMAGE_SELECTION_NAMES}" | cut -d " " -f $i | cut -d ":" -f 1)
 
     DEPLOY_DATA_JOB_JOB_NAME="notebookdeploy-${DEPLOY_DATA_JOB_JUPYTERHUB_IMAGE_NAME}"
     DEPLOY_DATA_JOB_JOB_DESCRIPTION="Auto-deploy tutorial notebooks for the image ${DEPLOY_DATA_JOB_DOCKER_IMAGE}"
 
     # Docker image to run deploy-date script.
+    echo "DEPLOY_DATA_JOB_DOCKER_IMAGE [${i}]: ${DEPLOY_DATA_JOB_DOCKER_IMAGE}"
     if [ -z "$DEPLOY_DATA_JOB_DOCKER_IMAGE" ]; then
         echo "Error: DEPLOY_DATA_JOB_DOCKER_IMAGE not set" 1>&2
-        exit 1
+        return 1
     fi
 
     # Name of the image found on the JupyterHub selection page, important for the path of the volume mount
     if [ -z "$DEPLOY_DATA_JOB_JUPYTERHUB_IMAGE_NAME" ]; then
         echo "Error: DEPLOY_DATA_JOB_JUPYTERHUB_IMAGE_NAME not set" 1>&2
-        exit 1
+        return 1
     fi
 
     # Log file location.  Default location under /var/log/PAVICS/ has built-in logrotate.
@@ -48,12 +53,12 @@ for i in $( seq 1 $(echo $DOCKER_NOTEBOOK_IMAGES | wc -w)) ; do
         DEPLOY_DATA_JOB_LOGFILE="${PAVICS_LOG_DIR}/${DEPLOY_DATA_JOB_JOB_NAME}.log"
     fi
 
-    if [ -z "`echo "$AUTODEPLOY_EXTRA_SCHEDULER_JOBS" | grep $DEPLOY_DATA_JOB_JOB_NAME`" ]; then
+    if [ -z "$(echo "$AUTODEPLOY_EXTRA_SCHEDULER_JOBS" | grep $DEPLOY_DATA_JOB_JOB_NAME)" ]; then
 
         # Add job only if not already added (config is read more than once during
         # autodeploy process).
 
-        LOGFILE_DIRNAME="`dirname "$DEPLOY_DATA_JOB_LOGFILE"`"
+        LOGFILE_DIRNAME="$(dirname "$DEPLOY_DATA_JOB_LOGFILE")"
 
         # Path where notebooks are deployed on the image running the script
         DEPLOY_DATA_JOB_NOTEBOOK_DEST_DIR=${JUPYTERHUB_USER_DATA_DIR}/tutorial-notebooks-specific-images/${DEPLOY_DATA_JOB_JUPYTERHUB_IMAGE_NAME}

--- a/scheduler-jobs/deploy_data_pavics_jupyter.env
+++ b/scheduler-jobs/deploy_data_pavics_jupyter.env
@@ -25,6 +25,8 @@ fi
 # Normalize the variable format in case it contains additional spaces or employs newlines.
 DOCKER_NOTEBOOK_IMAGES=$(echo "${DOCKER_NOTEBOOK_IMAGES}" | grep -oP '\S+' | tr '[:space:]' ' ')
 echo "DOCKER_NOTEBOOK_IMAGES: [${DOCKER_NOTEBOOK_IMAGES}]"
+JUPYTERHUB_IMAGE_SELECTION_NAMES=$(echo "${JUPYTERHUB_IMAGE_SELECTION_NAMES}" | grep -oP '\S+' | tr '[:space:]' ' ')
+echo "JUPYTERHUB_IMAGE_SELECTION_NAMES: [${JUPYTERHUB_IMAGE_SELECTION_NAMES}]"
 
 for i in $( seq 1 "$(echo "${DOCKER_NOTEBOOK_IMAGES}" | wc -w)" ) ; do
     DEPLOY_DATA_JOB_DOCKER_IMAGE=$(echo "${DOCKER_NOTEBOOK_IMAGES}" | cut -d " " -f $i)
@@ -37,28 +39,29 @@ for i in $( seq 1 "$(echo "${DOCKER_NOTEBOOK_IMAGES}" | wc -w)" ) ; do
 
     # Docker image to run deploy-date script.
     echo "DEPLOY_DATA_JOB_DOCKER_IMAGE [${i}]: ${DEPLOY_DATA_JOB_DOCKER_IMAGE}"
-    if [ -z "$DEPLOY_DATA_JOB_DOCKER_IMAGE" ]; then
+    if [ -z "${DEPLOY_DATA_JOB_DOCKER_IMAGE}" ]; then
         echo "Error: DEPLOY_DATA_JOB_DOCKER_IMAGE not set" 1>&2
         return 1
     fi
 
     # Name of the image found on the JupyterHub selection page, important for the path of the volume mount
-    if [ -z "$DEPLOY_DATA_JOB_JUPYTERHUB_IMAGE_NAME" ]; then
+    echo "DEPLOY_DATA_JOB_JUPYTERHUB_IMAGE_NAME [${i}]: ${DEPLOY_DATA_JOB_JUPYTERHUB_IMAGE_NAME}"
+    if [ -z "${DEPLOY_DATA_JOB_JUPYTERHUB_IMAGE_NAME}" ]; then
         echo "Error: DEPLOY_DATA_JOB_JUPYTERHUB_IMAGE_NAME not set" 1>&2
         return 1
     fi
 
     # Log file location.  Default location under /var/log/PAVICS/ has built-in logrotate.
-    if [ -z "$DEPLOY_DATA_JOB_LOGFILE" ]; then
+    if [ -z "${DEPLOY_DATA_JOB_LOGFILE}" ]; then
         DEPLOY_DATA_JOB_LOGFILE="${PAVICS_LOG_DIR}/${DEPLOY_DATA_JOB_JOB_NAME}.log"
     fi
 
-    if [ -z "$(echo "$AUTODEPLOY_EXTRA_SCHEDULER_JOBS" | grep $DEPLOY_DATA_JOB_JOB_NAME)" ]; then
+    if [ -z "$(echo "${AUTODEPLOY_EXTRA_SCHEDULER_JOBS}" | grep "${DEPLOY_DATA_JOB_JOB_NAME}")" ]; then
 
         # Add job only if not already added (config is read more than once during
         # autodeploy process).
 
-        LOGFILE_DIRNAME="$(dirname "$DEPLOY_DATA_JOB_LOGFILE")"
+        LOGFILE_DIRNAME="$(dirname "${DEPLOY_DATA_JOB_LOGFILE}")"
 
         # Path where notebooks are deployed on the image running the script
         DEPLOY_DATA_JOB_NOTEBOOK_DEST_DIR=${JUPYTERHUB_USER_DATA_DIR}/tutorial-notebooks-specific-images/${DEPLOY_DATA_JOB_JUPYTERHUB_IMAGE_NAME}


### PR DESCRIPTION
## Description

When parsing `DOCKER_NOTEBOOK_IMAGES` and/or `JUPYTERHUB_IMAGE_SELECTION_NAMES` generated from a similar `env.local` definition as in the example file: 
https://github.com/bird-house/birdhouse-deploy/blob/8218166d5c8c7163293a656930ff85762eff4b60/birdhouse/env.local.example#L266-L280
The script could fail if the `\` to make it a continuous string were omitted (therefore, literal `\n` are then encoded in the string).
Since `\n` are permitted almost anywhere else (eg: `EXTRA_CONF_DIRS`, `DELAYED_EVAL`, `OPTIONAL_VARS`, etc.), this caused very unintuitive errors. 
Now, any spaces can be used transparently. 
Python code in the JupyterHub component that use the same `DOCKER_NOTEBOOK_IMAGES` typically used `.split()` which handles any spaces in the same way as now done by this script.

## Example 

Output BEFORE:
```shell
. env.local
INFO:     Resolved 'DOCKER_NOTEBOOK_IMAGES=
  pavics/workflow-tests:py39-230601-1-update240116
  
  pavics/crim-jupyter-eo:0.3.0
  pavics/crim-jupyter-eo:0.4.0
  pavics/crim-jupyter-nlp:0.4.0
  pavics/crim-jupyter-nlp:0.5.0

'

. pavics-jupyter-base/scheduler-jobs/deploy_data_pavics_jupyter.env
DOCKER_NOTEBOOK_IMAGES: [
  
  
  pavics/crim-jupyter-eo:0.3.0
  pavics/crim-jupyter-eo:0.4.0
  pavics/crim-jupyter-nlp:0.4.0
  pavics/crim-jupyter-nlp:0.5.0

]
DEPLOY_DATA_JOB_DOCKER_IMAGE [1]: 
Error: DEPLOY_DATA_JOB_DOCKER_IMAGE not set
```

Output AFTER

```shell
. env.local
INFO:     Resolved 'DOCKER_NOTEBOOK_IMAGES=
  pavics/workflow-tests:py39-230601-1-update240116
  
  pavics/crim-jupyter-eo:0.3.0
  pavics/crim-jupyter-eo:0.4.0
  pavics/crim-jupyter-nlp:0.4.0
  pavics/crim-jupyter-nlp:0.5.0

'

. pavics-jupyter-base/scheduler-jobs/deploy_data_pavics_jupyter.env
DOCKER_NOTEBOOK_IMAGES: [pavics/workflow-tests:py39-230601-1-update240116 pavics/crim-jupyter-eo:0.3.0 pavics/crim-jupyter-eo:0.4.0 pavics/crim-jupyter-nlp:0.4.0 pavics/crim-jupyter-nlp:0.5.0 ]
DEPLOY_DATA_JOB_DOCKER_IMAGE [1]: pavics/workflow-tests:py39-230601-1-update240116
DEPLOY_DATA_JOB_DOCKER_IMAGE [2]: pavics/crim-jupyter-eo:0.3.0
DEPLOY_DATA_JOB_DOCKER_IMAGE [3]: pavics/crim-jupyter-eo:0.4.0
DEPLOY_DATA_JOB_DOCKER_IMAGE [4]: pavics/crim-jupyter-nlp:0.4.0
DEPLOY_DATA_JOB_DOCKER_IMAGE [5]: pavics/crim-jupyter-nlp:0.5.0
```

## Additional Information

@mishaschwartz @tlvu 
Not sure if you guys are using this script, so adding you for review just in case.